### PR TITLE
Updating morgan to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jsonwebtoken": "7.1.9",
     "method-override": "^2.3.5",
     "mongoose": "^4.12.1",
-    "morgan": "1.7.0",
+    "morgan": "^1.9.0",
     "winston": "2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION

Please update [morgan](https://npmjs.org/package/morgan) to version 1.9.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```4def0fa```](https://github.com/expressjs/morgan/commit/4def0fa6d4ac703dc5c76f901e997af667a27d65) ```1.9.0```
 * [```b29fc88```](https://github.com/expressjs/morgan/commit/b29fc884dd836960fabe65fe71db988bcb867371) ```docs: update license```
 * [```ddf4f8c```](https://github.com/expressjs/morgan/commit/ddf4f8c3227bed052d417f973f85bf265f9dccdc) ```Use res.headersSent when available```
 * [```7348b5c```](https://github.com/expressjs/morgan/commit/7348b5c4e5fd0e641f5fe1473bfdc39faae25954) ```docs: add example of split / dual logging```
 * [```98d62ee```](https://github.com/expressjs/morgan/commit/98d62eeb6484fe56262ee5efe0cf646b51cd4f65) ```docs: fix block formatting```
 * [```6fdf1a0```](https://github.com/expressjs/morgan/commit/6fdf1a01b6e2c495e61e16c9e9d985f20f6ad9a1) ```docs: fix typo```
 * [```a028ae7```](https://github.com/expressjs/morgan/commit/a028ae77ad5b5e9c5d537171dbd10af298f862dd) ```deps: basic-auth@~2.0.0```
 * [```4e4f07f```](https://github.com/expressjs/morgan/commit/4e4f07f5e4fee4ee2ca7aefb90f59cb95cbd4c6a) ```deps: debug@2.6.9```
 * [```67a1be6```](https://github.com/expressjs/morgan/commit/67a1be62ce15052e68dfa9cf25d02fa3f5cdfa56) ```build: Node.js@8.6```
 * [```188826e```](https://github.com/expressjs/morgan/commit/188826e6d444d0fd94464515275ba96c26fb3cbc) ```build: Node.js@6.11```
 * [```a5acdee```](https://github.com/expressjs/morgan/commit/a5acdee9e8654363dde7705dcd2c32910df80a17) ```build: eslint-plugin-node@5.1.1```
 * [```1ec7060```](https://github.com/expressjs/morgan/commit/1ec706015369d6ab07a327fafd10a52e2cbb6fd0) ```build: eslint-plugin-import@2.7.0```
 * [```b6c0d71```](https://github.com/expressjs/morgan/commit/b6c0d71f9752ae635a099e183e182961fd8f52e9) ```build: split@1.0.1```
 * [```bbcadcf```](https://github.com/expressjs/morgan/commit/bbcadcf8058679c76c58ccf372add219055bf672) ```deps: depd@~1.1.1```
 * [```bb8717a```](https://github.com/expressjs/morgan/commit/bb8717aabe85c114cb6f9c93d7ff3158235309d0) ```build: support Node.js 8.x```


See the full [change log](https://github.com/expressjs/morgan/compare/5da5ff1f5446e3f3ff29d29a2d6582712612bf89...4def0fa6d4ac703dc5c76f901e997af667a27d65) for everything that changed in this release.