### PR TITLE
Updating compression to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "body-parser": "^1.18.2",
-    "compression": "1.6.2",
+    "compression": "^1.7.1",
     "cookie-parser": "1.4.3",
     "cors": "2.8.1",
     "debug": "^2.6.9",


### PR DESCRIPTION

Please update [compression](https://npmjs.org/package/compression) to version 1.7.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```93586e7```](https://github.com/expressjs/compression/commit/93586e75a0a1c5bbfd353c4cec1cfcee2e52adde) ```1.7.1```
 * [```bd3fa8a```](https://github.com/expressjs/compression/commit/bd3fa8a80addbbc227bcaa5929a4373d76676a4b) ```deps: bytes@3.0.0```
 * [```e1ce980```](https://github.com/expressjs/compression/commit/e1ce980407814dca14c76cdd4e4aee61b56e4caa) ```deps: vary@~1.1.2```
 * [```d0f7eab```](https://github.com/expressjs/compression/commit/d0f7eab38f40e3bac0a4d32489a6b9accc0820fe) ```deps: debug@2.6.9```
 * [```931c346```](https://github.com/expressjs/compression/commit/931c3469a41205794cadf980967dabc40fe4c1d4) ```build: Node.js@8.4```
 * [```8c8e36a```](https://github.com/expressjs/compression/commit/8c8e36ab3196df83d2d89cd26936b6e7b4c368aa) ```deps: compressible@~2.0.11```
 * [```8a5e773```](https://github.com/expressjs/compression/commit/8a5e773aa9d4e27a3109bc7870e3582505c19eb9) ```deps: accepts@~1.3.4```
 * [```7b4a7e2```](https://github.com/expressjs/compression/commit/7b4a7e28bb5f37db5c1aa7fa6f60b2191588c275) ```build: eslint-plugin-node@5.1.1```
 * [```de30e3a```](https://github.com/expressjs/compression/commit/de30e3a3511544204060c8375183f322e50d2d24) ```build: mocha@2.5.3```
 * [```8c3f7ea```](https://github.com/expressjs/compression/commit/8c3f7eabba0be7dfb7fec86297cb28458efc3c58) ```1.7.0```
 * [```c27dc0f```](https://github.com/expressjs/compression/commit/c27dc0f27657b43d1efde44fcc3d79ad146e2b10) ```build: support Node.js 8.x```
 * [```d886306```](https://github.com/expressjs/compression/commit/d8863066779baa0684fae72647c6bda8a82b8a79) ```build: eslint-config-standard@10.2.1```
 * [```598d876```](https://github.com/expressjs/compression/commit/598d8768159249cfa6eca87e6bac8c81d6e64735) ```Use safe-buffer for improved Buffer API```
 * [```47fca12```](https://github.com/expressjs/compression/commit/47fca1282dc9d28c30fee056c53d3145c3100e05) ```build: eslint-plugin-markdown@1.0.0-beta.6```
 * [```3c78e39```](https://github.com/expressjs/compression/commit/3c78e39f248db6fcd238db5ffacc26c410f979cd) ```build: Node.js@6.11```


See the full [change log](https://github.com/expressjs/compression/compare/b9c63ced82b9f719cd5d9fd250c8432b00752d89...93586e75a0a1c5bbfd353c4cec1cfcee2e52adde) for everything that changed in this release.