### PR TITLE
Updating babel-preset-es2015 to 6.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-cli": "6.18.0",
     "babel-core": "6.18.0",
     "babel-plugin-add-module-exports": "0.2.1",
-    "babel-preset-es2015": "6.16.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "6.18.0",
     "bithound": "^1.7.0",
     "chai": "^3.4.1",


### PR DESCRIPTION

Please update [babel-preset-es2015](https://npmjs.org/package/babel-preset-es2015) to version 6.24.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

