### PR TITLE
Updating babel-core to 6.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
-    "babel-core": "6.18.0",
+    "babel-core": "^6.26.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "6.18.0",


### PR DESCRIPTION

Please update [babel-core](https://npmjs.org/package/babel-core) to version 6.26.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

