### PR TITLE
Updating babel-cli to 6.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "winston": "^2.4.0"
   },
   "devDependencies": {
-    "babel-cli": "6.18.0",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION

Please update [babel-cli](https://npmjs.org/package/babel-cli) to version 6.26.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

