### PR TITLE
Updating babel-preset-stage-2 to 6.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-core": "^6.26.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-2": "6.18.0",
+    "babel-preset-stage-2": "^6.24.1",
     "bithound": "^1.7.0",
     "chai": "^3.4.1",
     "commitizen": "^2.9.2",


### PR DESCRIPTION

Please update [babel-preset-stage-2](https://npmjs.org/package/babel-preset-stage-2) to version 6.24.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

