### PR TITLE
Updating mongoose to 4.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "joi": "^11.3.4",
     "jsonwebtoken": "7.1.9",
     "method-override": "^2.3.5",
-    "mongoose": "^4.12.1",
+    "mongoose": "^4.12.2",
     "morgan": "^1.9.0",
     "winston": "^2.4.0"
   },


### PR DESCRIPTION

Please update [mongoose](https://npmjs.org/package/mongoose) to version 4.12.2.

If this passes your tests you can merge it in.  If not please use this branch for changes.



View the [change log](https://github.com/Automattic/mongoose/compare/f2170ee2a6bab60982f04ee54a153314d7ebe405...f2170ee2a6bab60982f04ee54a153314d7ebe405).