### PR TITLE
Updating run-sequence to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "istanbul": "1.1.0-alpha.1",
     "mocha": "3.2.0",
     "punycode": "false2.1.0",
-    "run-sequence": "^1.1.5",
+    "run-sequence": "^2.2.0",
     "supertest": "2.0.1",
     "supertest-as-promised": "4.0.2",
     "validate-commit-msg": "false2.14.0"


### PR DESCRIPTION

Please update [run-sequence](https://npmjs.org/package/run-sequence) to version 2.2.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```37e17be```](https://github.com/OverZealous/run-sequence/commit/37e17be41a0e40771cd7eb8cdc474370b150f2ce) ```2.2.0```
 * [```c450122```](https://github.com/OverZealous/run-sequence/commit/c450122365b3342eca6c4853de750ed5f1091687) ```Changelog, cleanup for orchestration events change```
 * [```2155560```](https://github.com/OverZealous/run-sequence/commit/21555608ef21ad91b660b1da8fc78d6f9f8c6111) ```handle orchestration aborted events (#97)```
 * [```066b8c6```](https://github.com/OverZealous/run-sequence/commit/066b8c657ee9a8677713c25f32380c15207d693c) ```2.1.0```
 * [```dada3f4```](https://github.com/OverZealous/run-sequence/commit/dada3f4d3078352626ca7eafe4e386a92a97575e) ```Added date to v1 in changelog```
 * [```f2b1635```](https://github.com/OverZealous/run-sequence/commit/f2b16350968ccabf3711dde1f14f007f884369bb) ```Added options, code cleanup```
 * [```578d017```](https://github.com/OverZealous/run-sequence/commit/578d01790538e298cb83dc82ab4c19bcf30b3df4) ```Added a changelog, Closes #82```
 * [```9fd7783```](https://github.com/OverZealous/run-sequence/commit/9fd7783f0f756ba6fb5a36049507422d8f91d95b) ```2.0.0```
 * [```d80ddf5```](https://github.com/OverZealous/run-sequence/commit/d80ddf538f32f29d67045f36f6e63e66c0b9cffe) ```Specify chalk version (#89)```
 * [```59515cf```](https://github.com/OverZealous/run-sequence/commit/59515cf296e1bb3d37e60c72add907dc4a21f009) ```Fixed typo```
 * [```7e263af```](https://github.com/OverZealous/run-sequence/commit/7e263affdc0a657c0fedcbb5230d3a8734f08643) ```Ignore yarn lock when publishing```
 * [```b83cc34```](https://github.com/OverZealous/run-sequence/commit/b83cc34cecd5ee4d3c0458be8f60988baeabaf8f) ```Adding Yarn lockfile```
 * [```ee04d48```](https://github.com/OverZealous/run-sequence/commit/ee04d4851f3c68f160c98d0504c7c7b6b5ebfb86) ```Added modern node versions to travis ci (#73)```


View the [change log](https://github.com/OverZealous/run-sequence/compare/2238f6aea94c201173a99a4ccc1f2791c38531a1...37e17be41a0e40771cd7eb8cdc474370b150f2ce).