### PR TITLE
Updating chai to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "bithound": "^1.7.0",
-    "chai": "^3.4.1",
+    "chai": "^4.1.2",
     "commitizen": "^2.9.2",
     "coveralls": "^2.11.6",
     "cross-env": "3.1.3",


### PR DESCRIPTION

Please update [chai](https://npmjs.org/package/chai) to version 4.1.2.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```529d395```](https://github.com/chaijs/chai/commit/529d395fa08091af2a02a8398b1144c51ed62178) ```Merge pull request #1037 from Cutlery-Drawer/master```
 * [```b534fca```](https://github.com/chaijs/chai/commit/b534fca6c03c4ac27a451acb514d9084868e6aa1) ```chai@4.1.2```
 * [```c592551```](https://github.com/chaijs/chai/commit/c5925517957c998c3167109a0db7f2738a5a8a05) ```Merge pull request #1032 from Cutlery-Drawer/csp-fix```
 * [```31c3559```](https://github.com/chaijs/chai/commit/31c35595d7ea5a2e71e92a9e24446925a0c898da) ```Use a hardcoded no-op instead of instancing```
 * [```1ae9386```](https://github.com/chaijs/chai/commit/1ae9386901ee01dffeb1eb377668abc8d510a0f8) ```Merge pull request #1025 from yanca018/master```
 * [```786043b```](https://github.com/chaijs/chai/commit/786043bffc4a3ab9eaf2ba1e479f8848dcc1c6a8) ```Update license```
 * [```7c1ca16```](https://github.com/chaijs/chai/commit/7c1ca16fb38d03910b1d95962dc18bb063a21391) ```docs: add missing assert parameters (#1023)```
 * [```6e72c5a```](https://github.com/chaijs/chai/commit/6e72c5ac9a9fc77af00ae6b9331e9d46fb2fbb96) ```fix(package): update deep-eql to version 3.0.0 (#1&hellip;```
 * [```02ddebd```](https://github.com/chaijs/chai/commit/02ddebd8f274ba94f9eb95c1c8c21176be6fe20c) ```Merge pull request #1019 from meeber/release-4.1.1```
 * [```ac48db3```](https://github.com/chaijs/chai/commit/ac48db3a72bd3a5a6846c20aac6e2fc573cfc98a) ```chai@4.1.1```
 * [```d2e9599```](https://github.com/chaijs/chai/commit/d2e9599bec769ee0cdaef5f9a67ed53ec102d769) ```Merge pull request #1016 from chaijs/fix-reindent-code-1014```
 * [```92d2cca```](https://github.com/chaijs/chai/commit/92d2cca46833f64ab9960964baa08901c1e7431d) ```docs: re-indent hasAnyKeys code```
 * [```b625497```](https://github.com/chaijs/chai/commit/b625497f1eeebffcad6c759758b5142ddf2168bd) ```Merge pull request #1012 from meeber/fix-include-types```
 * [```8fa24f2```](https://github.com/chaijs/chai/commit/8fa24f2972fe3082300d0638ebd5779c809f72b8) ```Merge pull request #1014 from zenHeart/fix-hasAnyKeys-comment```
 * [```113a5b8```](https://github.com/chaijs/chai/commit/113a5b8b6aa6b85cb4a5854bd85ad3f29ad8cf1e) ```fix: correct hasAnyKeys comment error```


See the full [change log](https://github.com/chaijs/chai/compare/4ca0218391cf947c6cfac2d1a7424a63a4b4c232...529d395fa08091af2a02a8398b1144c51ed62178) for everything that changed in this release.