### PR TITLE
Updating cross-env to 5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "chai": "^4.1.2",
     "commitizen": "^2.9.2",
     "coveralls": "^2.11.6",
-    "cross-env": "3.1.3",
+    "cross-env": "^5.0.5",
     "cz-conventional-changelog": "^2.0.0",
     "del": "^3.0.0",
     "eslint": "^4.9.0",


### PR DESCRIPTION

Please update [cross-env](https://npmjs.org/package/cross-env) to version 5.0.5.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```44b37dd```](https://github.com/kentcdodds/cross-env/commit/44b37dd1ae28f81b10c4411d693c43a4c431f4e4) ```fix(docs): add malware warning to README```
 * [```c03ec7a```](https://github.com/kentcdodds/cross-env/commit/c03ec7a2b6c53e17c6e51e742570122d4af68505) ```fix: Don't pass fn reference(`commandConvert`) to `commandArgs.map` (#135)```
 * [```277cf07```](https://github.com/kentcdodds/cross-env/commit/277cf075d65ce2470316b46f2ae962a8bb174ec9) ```fix: Normalize command only and not command args(windows) (#134)```
 * [```601632d```](https://github.com/kentcdodds/cross-env/commit/601632d37f39f5a58a5de55297020bb0599d4858) ```test: Fix EventEmitter.MaxListenersExceededWarning warning (#132)```
 * [```0fe3482```](https://github.com/kentcdodds/cross-env/commit/0fe348244290dd3f10804550ccd898e1f1b31409) ```chore: rm yarn.lock, add lock files to .gitignore (#131)```
 * [```487241d```](https://github.com/kentcdodds/cross-env/commit/487241db78eb6343726fe09643b2402a4e920e4e) ```fix: Handle relative path in cmd on windows (#130)```
 * [```f83a163```](https://github.com/kentcdodds/cross-env/commit/f83a163b79dd48fa0204fbc10d2a2c5f801e8fdd) ```chore(deps): updated package babel-cli from 6.23.0&hellip;```
 * [```b10de51```](https://github.com/kentcdodds/cross-env/commit/b10de512868e6b591f9d735fbe83c7fe2821e7b8) ```fix: Change splitter regex to use .* instead of .+ (#117)```
 * [```c9908f3```](https://github.com/kentcdodds/cross-env/commit/c9908f364f86905f36297886127aa992f92350b8) ```test(JSON): add JSON value tests that work on both Windows and UNIX (#112)```
 * [```9c4f346```](https://github.com/kentcdodds/cross-env/commit/9c4f3462a302e222ad40a3b65086164927da01c3) ```fix(bin): add a bin entry for cross-env-shell```
 * [```d7b48d5```](https://github.com/kentcdodds/cross-env/commit/d7b48d5ce124cf211150c7142ae5e0339118e509) ```feat(bin): two bins (shell, non-shell) (#104)```
 * [```3881423```](https://github.com/kentcdodds/cross-env/commit/38814238a5c5b82394745b32620c334b82592e23) ```feat: don't change colons on non-PATH/NODE_PATH on win32 (#107)```
 * [```6994a24```](https://github.com/kentcdodds/cross-env/commit/6994a24dfa9ed759598ac94e35fe52b2508b7a88) ```docs(contributors): add amilajack to contributors (#98)```
 * [```e8a1614```](https://github.com/kentcdodds/cross-env/commit/e8a1614683fad01b2927ac8a4be308a21aa7df98) ```fix: Resolve value of env variables before invoking cross-spawn (#95)```
 * [```9e0ea05```](https://github.com/kentcdodds/cross-env/commit/9e0ea056e303f196f1b8f176b23fcc54d097a4af) ```docs(engine): revert support to node 4 (#96)```


See the full [change log](https://github.com/kentcdodds/cross-env/compare/01df20862ec0dce118baf97ea6de2625ad64066c...44b37dd1ae28f81b10c4411d693c43a4c431f4e4) for everything that changed in this release.