### PR TITLE
Updating eslint-config-airbnb-base to 12.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "del": "^3.0.0",
     "eslint": "^4.9.0",
-    "eslint-config-airbnb-base": "7.1.0",
+    "eslint-config-airbnb-base": "^12.0.2",
     "eslint-plugin-import": "^2.7.0",
     "eslint-watch": "^3.1.3",
     "gulp": "^3.9.1",


### PR DESCRIPTION

Please update [eslint-config-airbnb-base](https://npmjs.org/package/eslint-config-airbnb-base) to version 12.0.2.

If this passes your tests you can merge it in.  If not please use this branch for changes.

