### PR TITLE
Updating gulp-sourcemaps to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "gulp-load-plugins": "^1.5.0",
     "gulp-newer": "^1.1.0",
     "gulp-nodemon": "^2.0.6",
-    "gulp-sourcemaps": "^1.6.0",
+    "gulp-sourcemaps": "^2.6.1",
     "gulp-util": "^3.0.7",
     "husky": "^0.14.3",
     "istanbul": "1.1.0-alpha.1",


### PR DESCRIPTION

Please update [gulp-sourcemaps](https://npmjs.org/package/gulp-sourcemaps) to version 2.6.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```4b723f0```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/4b723f0253cf089db09d8f209a5a374394c4c185) ```bump 2.6.1```
 * [```92c489c```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/92c489c628acda58c542a57b7239de00ce1829d0) ```Merge pull request #323 from gulp-sourcemaps/nmccready/loggingMemleak```
 * [```da4cdb2```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/da4cdb2d0fddff1d2d349d92799f5e80a9c1c0d6) ```fix npm```
 * [```a21f037```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/a21f037882addaee12d253da307cde7b01372dfc) ```fix: issue 317 memory leak on logging```
 * [```65d099a```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/65d099a3f318f4f6cfbbf2f087118dd3f68025b7) ```2.6.0```
 * [```44801fa```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/44801fa6c869ac8179c8489429c4f6b72e314345) ```Deprecate options.identityMap and export identityM&hellip;```
 * [```8039c13```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/8039c13981e1d620359b45cf5d153decd8c9136a) ```2.5.2```
 * [```ee64234```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/ee64234e1d1ed6a47ac162a8bc88ef82c8c92d19) ```Update organization references (closes #289)```
 * [```9857f3f```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/9857f3f85713d871f1b583345983f71363e1cb6b) ```Logging Improvements (#301)```
 * [```0765da0```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/0765da06671db73075e91b7643d3e4f63d79453f) ```2.5.1```
 * [```92aa56c```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/92aa56c1bff7fa44d2f82cc42da6bb393ccecf20) ```Merge pull request #299 from gulp-sourcemaps/2.x-node-0.10```
 * [```b6265a8```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/b6265a87b2c18c38cf5c6a91378eb8a3d0b11e84) ```Switch to strip-bom-string to support 0.10+ in 2.x```
 * [```4a3b159```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/4a3b15963d09d70dec0c56ca73fdd4be0ab777ef) ```2.5.0```
 * [```1539835```](https://github.com/gulp-sourcemaps/gulp-sourcemaps/commit/15398353fc83d5b9ca2965bb04168a96995857de) ```Merge branch '1.X'```


View the [change log](https://github.com/gulp-sourcemaps/gulp-sourcemaps/compare/260b5cd0b9f351d273cd567c7284368f35cc0368...4b723f0253cf089db09d8f209a5a374394c4c185).